### PR TITLE
fix undefined variable in Epoch.tt2ut

### DIFF
--- a/pymeeus/Epoch.py
+++ b/pymeeus/Epoch.py
@@ -1400,6 +1400,7 @@ class Epoch(object):
                 )
             )
         elif year >= 500 and year < 1600:
+            u = (year - 1000) / 100.0
             dt = 1574.2 + u * (
                 -556.01
                 + u

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -267,6 +267,27 @@ def test_epoch_tt2ut():
     assert abs(round(Epoch.tt2ut(2015, 7), 1) - 69.3) < TOL, \
         "ERROR: 6th tt2ut() test, output doesn't match"
 
+    assert abs(round(Epoch.tt2ut(1000, 1), 1) - 1574.2) < TOL, \
+        "ERROR: 7th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(-501, 1), 1) - 17218.5) < TOL, \
+        "ERROR: 8th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(1801, 1), 1) - 13.4) < TOL, \
+        "ERROR: 9th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(1930, 1), 1) - 24.1) < TOL, \
+        "ERROR: 10th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(1945, 1), 1) - 26.9) < TOL, \
+        "ERROR: 11th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(1970, 1), 1) - 40.2) < TOL, \
+        "ERROR: 12th tt2ut() test, output doesn't match"
+
+    assert abs(round(Epoch.tt2ut(2000, 1), 1) - 63.9) < TOL, \
+        "ERROR: 13th tt2ut() test, output doesn't match"
+
 
 def test_epoch_dow():
     """Tests the dow() method of Epoch class"""


### PR DESCRIPTION
This fixes an error in `Epoch.tt2ut`, where it failed with an `UnboundLocalError` for years in the range [500, 1600).

minimal example of the error:
```python
from pymeeus.Epoch import Epoch
#  These succeed:
Epoch.tt2ut(1600, 1) 
Epoch.tt2ut(499, 1)
#  These fail with the below error
Epoch.tt2ut(500, 1)
Epoch.tt2ut(1599, 1) 
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "/path/to/python3.9/site-packages/PyMeeus-0.3.7-py3.9.egg/pymeeus/Epoch.py", line 1403, in tt2ut
# UnboundLocalError: local variable 'u' referenced before assignment
```

The fix was easy to add since the function is well-documented and includes a link to the [source material](https://eclipse.gsfc.nasa.gov/LEcat5/deltatpoly.html).

I also expanded the tests of `tt2ut` to include checks of a year in the above-mentioned range and other year ranges used in the function.