### PR TITLE
Unicode error when installing on old platform

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ PyMeeus
    **Library of astronomical algorithms in Python**.
 
 PyMeeus is a Python implementation of the astronomical algorithms
-described in the classical book “Astronomical Algorithms, 2nd Edition,
-Willmann-Bell Inc. (1998)” by Jean Meeus.
+described in the classical book "Astronomical Algorithms, 2nd Edition,
+Willmann-Bell Inc. (1998)" by Jean Meeus.
 
 There are great astronomical libraries out there. For instance, if
 you’re looking for high precision and speed you should take a look at


### PR DESCRIPTION
Fixes the following error:

```
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-wheel-4g4alnkl/pymeeus/setup.py", line 13, in <module>
        long_description = f.read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 169: ordinal not in range(128)
 ```