### PR TITLE
makes Epoch hashable

### DIFF
--- a/pymeeus/Epoch.py
+++ b/pymeeus/Epoch.py
@@ -198,6 +198,9 @@ class Epoch(object):
         self._jde = 0.0
         self.set(*args, **kwargs)  # Use 'set()' method to handle the setup
 
+    def __hash__(self):
+        return float(self).__hash__()
+
     def set(self, *args, **kwargs):
         """Method used to set the value of this object.
 

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -49,6 +49,12 @@ def test_epoch_constructor():
         "ERROR: 5th constructor test, JDE value doesn't match"
 
 
+def test_epoch_hashable():
+    a = Epoch(1987, 6, 19.5)
+    # can use as a key to a dict
+    _ = {a: 1}
+
+
 def test_epoch_is_julian():
     """Tests the is_julian() static method of Epoch class"""
 


### PR DESCRIPTION
This PR adds a `__hash__` method to the `Epoch` class. This lets epochs be used as the key of a dictionary and let's `functools.lru_cache` on functions of `Epoch`s