### PR TITLE
fix pytest 7.2 compatibility

### DIFF
--- a/tests/test_curvefitting.py
+++ b/tests/test_curvefitting.py
@@ -31,9 +31,8 @@ cf3 = CurveFitting()
 cf4 = CurveFitting()
 
 
-def setup():
+def setup_module():
     """This function is used to set up the environment for the tests"""
-
     # Set up a few CurveFitting objects
     cf1.set([73.0, 38.0, 35.0, 42.0, 78.0, 68.0, 74.0, 42.0, 52.0, 54.0, 39.0,
              61.0, 42.0, 49.0, 50.0, 62.0, 44.0, 39.0, 43.0, 54.0, 44.0, 37.0],
@@ -58,8 +57,13 @@ def setup():
              -0.8372, -0.4377, -0.3640, -0.3508, -0.2126])
 
 
-def teardown():
+def teardown_module():
     pass
+
+
+# pre pytest 7.2 compatibility
+setup = setup_module
+teardown = teardown_module
 
 
 # CurveFitting class

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -32,7 +32,7 @@ i_angles2 = Interpolation()
 i_sine = Interpolation()
 
 
-def setup():
+def setup_module():
     """This function is used to set up the environment for the tests"""
     # Set up a interpolation object which uses Right Ascension
     y0 = Angle(10, 18, 48.732, ra=True)
@@ -64,8 +64,13 @@ def setup():
                 0.5236885653, 0.5453707057])
 
 
-def teardown():
+def teardown_module():
     pass
+
+
+# pre pytest 7.2 ompatibility
+setup = setup_module
+teardown = teardown_module
 
 
 # Interpolation class


### PR DESCRIPTION
Pytest 7.2 deprecated plain top-level `setup()` and `teardown()` functions in favor of their own decorators:

https://docs.pytest.org/en/latest/changelog.html#pytest-7-2-0-2022-10-23 https://docs.pytest.org/en/latest/deprecations.html#setup-teardown

Now we need to use module-level setup/teardown, which is extremely similar, just named differently:

https://docs.pytest.org/en/latest/how-to/xunit_setup.html#module-level-setup-teardown

We keep compatibility shims for older pytest releases.

Closes: #24