### PR TITLE
Fix: Sign of T^3 term in mean perigee/apogee time

### DIFF
--- a/pymeeus/Moon.py
+++ b/pymeeus/Moon.py
@@ -895,7 +895,7 @@ class Moon(object):
         t = k / 1325.55
         # Compute the time of the 'mean' perigee or apogee
         jde = (2451534.6698 + 27.55454989 * k
-               + (-0.0006691 + (0.000001098 + 0.0000000052 * t) * t) * t * t)
+               + (-0.0006691 + (-0.000001098 + 0.0000000052 * t) * t) * t * t)
         # Moon's mean elongation at jde
         D = (171.9179 + 335.9106046 * k
              + (-0.0100383 + (-0.00001156 + 0.000000055 * t) * t) * t * t)


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* formula (50.1), the cubic (T³) term is subtracted, not added.

Excerpt from the book:
<img width="1094" height="250" alt="image" src="https://github.com/user-attachments/assets/1f5deedc-feba-4995-bc14-bcd8d3eeb692" />

Another reference:
https://github.com/hodinkee/aaplus/blob/29c6a5bfbff23edcb6a8f1018e83280d1eaf2ccc/src/AAMoonPerigeeApogee.h#L57