### PR TITLE
Fix: Use date-dependent DeltaT instead of hardcoded value in Sun.ephemeris_physical_observations

### DIFF
--- a/pymeeus/Sun.py
+++ b/pymeeus/Sun.py
@@ -649,7 +649,8 @@ class Sun(object):
         if not isinstance(epoch, Epoch):
             raise TypeError("Invalid input type")
         # Compute the auxiliary parameters
-        epoch += 0.00068
+        year, month, _ = epoch.get_date()
+        epoch += Epoch.tt2ut(year, month) / 86400.0
         theta = (epoch() - 2398220.0) * 360.0 / 25.38
         theta = Angle(theta)
         i = Angle(7.25)


### PR DESCRIPTION
In Meeus *Astronomical Algorithms* ch. 29, p. 189, he notes that if your input time is in Universal Time, you should first convert it to JD. You do that by adding DeltaT/86400, **where DeltaT is the value for the date in question** (as described in Chapter 10).

<img width="801" height="114" alt="image" src="https://github.com/user-attachments/assets/c9689533-4fbd-49d7-b3d1-3bc3af68fc4a" />
  
Meeus' Example 29.a (p. 190) uses `ΔT = +59 s = +0.00068 day` because that is the value of DeltaT for 13 October 1992.  
He is not using `0.00068` as a constant.

<img width="781" height="95" alt="image" src="https://github.com/user-attachments/assets/086bb271-d194-45b5-8ddf-d1645cdcd24e" />

Currently the example's value is hardcoded so every call uses the 1992-specific DeltaT regardless of the actual date.

This project exposes `Epoch.tt2ut(year, month)` returning DeltaT in seconds.  
The fix is to replace the hardcoded value by the date-dependent DeltaT value and converting it from seconds to day.