### PR TITLE
Fix: Preserve quadrant of eta in Sun.ephemeris_physical

### DIFF
--- a/pymeeus/Sun.py
+++ b/pymeeus/Sun.py
@@ -667,7 +667,7 @@ class Sun(object):
         p = x + y
         b0 = asin(sin(delta.rad()) * sin(i.rad()))
         b0 = Angle(b0, radians=True)
-        eta = atan(tan(delta.rad()) * cos(i.rad()))
+        eta = atan2(-sin(delta.rad()) * cos(i.rad()), -cos(delta.rad()))
         eta = Angle(eta, radians=True)
         l0 = eta - theta
         return p, b0, l0.to_positive()


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* ch. 29, p. 190, the angle `eta` is defined with the explicit constraint that "η being in the same quadrant as λ - K ± 180°":  
<img width="649" height="129" alt="image" src="https://github.com/user-attachments/assets/f546d014-399a-4fc9-827d-65f8560ee25c" />

Whenever `cos(λ - K) < 0` (about half of every year) `eta` ends up 180° off.


This is the same bug AA+ had in the past (history note in `AAPhysicalSun.cpp`: "Fixed an issue in CAAPhysicalSun::Calculate where the value "eta" would sometimes not be returned in the correct quadrant.").

Fixed line in AA+: https://github.com/hodinkee/aaplus/blob/29c6a5bfbff23edcb6a8f1018e83280d1eaf2ccc/src/AAPhysicalSun.cpp#L71