### PR TITLE
Fix: Inverted leap/common K in `Epoch.get_doy`

### DIFF
--- a/pymeeus/Epoch.py
+++ b/pymeeus/Epoch.py
@@ -786,7 +786,7 @@ class Epoch(object):
                 raise ValueError("Invalid input date")
             doy = d.timetuple().tm_yday
         else:
-            k = 2 if Epoch.is_leap(yyyy) else 1
+            k = 1 if Epoch.is_leap(yyyy) else 2
             doy = (iint((275.0 * mm) / 9.0)
                    - k * iint((mm + 9.0) / 12.0) + day - 30.0)
         return float(doy + frac)

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -150,6 +150,15 @@ def test_epoch_get_doy():
     assert Epoch.get_doy(-400, 2, 29.9) == 60.9, \
         "ERROR: 3rd get_doy() test, output doesn't match"
 
+    assert Epoch.get_doy(-1000, 7, 12) == 194, \
+        "ERROR: 4th get_doy() test, output doesn't match"
+
+    assert Epoch.get_doy(-5, 3, 1) == 60, \
+        "ERROR: 5th get_doy() test, output doesn't match"
+
+    assert Epoch.get_doy(-4, 3, 1) == 61, \
+        "ERROR: 6th get_doy() test, output doesn't match"
+
 
 def test_epoch_doy():
     """Tests the doy() method of Epoch class"""


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* 2nd ed. (ch. 7, p. 65), `Epoch.get_doy` uses the wrong `K` constant for years below +1: leap years should use `K = 1` and common years `K = 2`, but the code has them inverted.

Excerpt from the book:
<img width="800" height="312" alt="image" src="https://github.com/user-attachments/assets/c92f8f84-29ff-4362-b414-3b2853fb5e2e" />
