### PR TITLE
Fix: Dates before 1582 use the wrong calendar for day-of-year

### DIFF
--- a/pymeeus/Epoch.py
+++ b/pymeeus/Epoch.py
@@ -779,7 +779,7 @@ class Epoch(object):
             raise ValueError("Invalid input data")
         day = int(dd)
         frac = dd % 1
-        if yyyy >= 1:  # datetime's minimum year is 1
+        if yyyy >= 1582:
             try:
                 d = datetime.date(yyyy, mm, day)
             except ValueError:

--- a/tests/test_epoch.py
+++ b/tests/test_epoch.py
@@ -150,6 +150,9 @@ def test_epoch_get_doy():
     assert Epoch.get_doy(-400, 2, 29.9) == 60.9, \
         "ERROR: 3rd get_doy() test, output doesn't match"
 
+    assert Epoch.get_doy(1500, 12, 31) == 366, \
+        "ERROR: 4th get_doy() test, output doesn't match"
+
 
 def test_epoch_doy():
     """Tests the doy() method of Epoch class"""


### PR DESCRIPTION
The Gregorian calendar was adopted on 15 October 1582.
Before that date, the Julian calendar was in use. The two calendars differ in their leap-year rule:

- **Julian:** every year divisible by 4 is a leap year.
- **Gregorian:** divisible by 4, except century years not divisible by 400.

As a result, the following century years are leap years in the Julian calendar but not in the Gregorian calendar:
100, 200, 300, 500, 600, 700, 900, 1000, 1100, 1300, 1400, 1500.

`pymeeus.Epoch` handles this calendar distinction correctly in two of its three calendar-sensitive methods:

| Method | Cutover | Calendar < cutover |
|--------|---------|-------------------|
| `get_date()` | JD 2299161 (~Oct 1582) | Julian |
| `is_leap()` | year 1582 | Julian (divisible by 4) |
| `get_doy()` | **year 1** | **proleptic Gregorian** via `datetime` |

The mismatch is `get_doy()`: it uses year 1 as its cutover (the minimum `datetime.date` can represent), not 1582.

**First issue:** ValueError exception on Julian leap days
```python
>>> from pymeeus.Epoch import Epoch
>>> e = Epoch(1000, 2, 29.0)
>>> y, m, d = e.get_date()     # (1000, 2, 29.0) - valid Julian date
>>> Epoch.get_doy(y, m, d)     # datetime.date(1000, 2, 29) -> ValueError
Traceback (most recent call last):
  File "/Users/bueny/Documents/private/pymeeus/pymeeus/Epoch.py", line 784, in get_doy
    d = datetime.date(yyyy, mm, day)
ValueError: day is out of range for month

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import platform
  File "/Users/bueny/Documents/private/pymeeus/pymeeus/Epoch.py", line 786, in get_doy
    raise ValueError("Invalid input date")
ValueError: Invalid input date
```

Affected years: 100, 200, 300, 500, 600, 700, 900, 1000, 1100, 1300, 1400, 1500

**Second issue:** For dates March-December in the upper affected years, `datetime` computes DOY with 28 February days (Gregorian) instead of 29 (Julian).

Before this fix:
```python
>>> from pymeeus.Epoch import Epoch
>>> Epoch.get_doy(100, 12, 31)
365.0
```

After this fix:
```python
>>> from pymeeus.Epoch import Epoch
>>> Epoch.get_doy(100, 12, 31)
366.0
```

To work correctly, this PR should be merged after https://github.com/architest/pymeeus/pull/38