### PR TITLE
Fix: Avoid in-place overwrite in rectangular_coordinates_b1950

### DIFF
--- a/pymeeus/Sun.py
+++ b/pymeeus/Sun.py
@@ -395,10 +395,10 @@ class Sun(object):
         x = r * cos(lat.rad()) * cos(lon.rad())
         y = r * cos(lat.rad()) * sin(lon.rad())
         z = r * sin(lat.rad())
-        x = 0.999925702634 * x + 0.012189716217 * y + 0.000011134016 * z
-        y = -0.011179418036 * x + 0.917413998946 * y - 0.397777041885 * z
-        z = -0.004859003787 * x + 0.397747363646 * y + 0.917482111428 * z
-        return x, y, z
+        x_0 = 0.999925702634 * x + 0.012189716217 * y + 0.000011134016 * z
+        y_0 = -0.011179418036 * x + 0.917413998946 * y - 0.397777041885 * z
+        z_0 = -0.004859003787 * x + 0.397747363646 * y + 0.917482111428 * z
+        return x_0, y_0, z_0
 
     @staticmethod
     def rectangular_coordinates_equinox(epoch, equinox_epoch):

--- a/tests/test_sun.py
+++ b/tests/test_sun.py
@@ -135,10 +135,10 @@ def test_rectangular_coordinates_b1950():
     assert abs(round(x, 8) - (-0.94149557)) < TOL, \
         "ERROR: 1st rectangular_coordinates_b1950() test, 'x' doesn't match"
 
-    assert abs(round(y, 8) - (-0.30259922)) < TOL, \
+    assert abs(round(y, 8) - (-0.30264495)) < TOL, \
         "ERROR: 2nd rectangular_coordinates_b1950() test, 'y' doesn't match"
 
-    assert abs(round(z, 8) - (-0.11578695)) < TOL, \
+    assert abs(round(z, 8) - (-0.13120549)) < TOL, \
         "ERROR: 3rd rectangular_coordinates_b1950() test, 'z' doesn't match"
 
 


### PR DESCRIPTION
Per Meeus, *Astronomical Algorithms* 2nd ed. (ch. 26, p. 174), the B1950 formulas compute new values from the original `x`, `y` and `z`. They should not reuse values that have already been updated.

Excerpt from the book:

<img width="821" height="364" alt="image" src="https://github.com/user-attachments/assets/24add16f-5d64-45ed-8651-68434d68b49d" />


Cross-check test values: https://github.com/soniakeys/meeus/blob/bfbd9ac2c7f709c94f1dee190c633d24a723f628/v3/solarxyz/pp_test.go#L66