### PR TITLE
Fix: Correct beta/b' mixup in Saturn.ring_parameters

### DIFF
--- a/pymeeus/Saturn.py
+++ b/pymeeus/Saturn.py
@@ -6713,7 +6713,7 @@ class Saturn(object):
         U1r = atan2((sin(ir) * sin(bprimer) + cos(ir) * cos(bprimer)
                      * sin(diff1)), (cos(bprimer) * cos(diff1)))
         diff2 = lambdar - Omegar
-        U2r = atan2((sin(ir) * sin(betar) + cos(ir) * cos(bprimer)
+        U2r = atan2((sin(ir) * sin(betar) + cos(ir) * cos(betar)
                      * sin(diff2)), (cos(betar) * cos(diff2)))
         delta_U = Angle(fabs(U1r - U2r), radians=True)
         B = Angle(B, radians=True)


### PR DESCRIPTION
Per Meeus, *Astronomical Algorithms* 2nd ed. (ch. 45, p. 319), U2 should use beta throughout the formula.

Excerpt from the book:

<img width="811" height="282" alt="image" src="https://github.com/user-attachments/assets/11cbeb2c-54e7-4f11-a6c6-39f554cb5a19" />



Comparison: https://github.com/soniakeys/meeus/blob/bfbd9ac2c7f709c94f1dee190c633d24a723f628/v3/saturnring/saturnring.go#L103