### PR TITLE
Fix: Near-pole declination in precession

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -581,7 +581,7 @@ def precession_equatorial(
     ) + cos(theta.rad()) * sin(start_dec.rad())
     final_ra = atan2(a, b) + z.rad()
     if start_dec > 85.0:  # Coordinates are close to the pole
-        final_dec = sqrt(a * a + b * b)
+        final_dec = acos(sqrt(a * a + b * b))
     else:
         final_dec = asin(c)
     # Convert results to Angles. Please note results are in radians
@@ -816,7 +816,7 @@ def precession_newcomb(
     ) + cos(theta.rad()) * sin(start_dec.rad())
     final_ra = atan2(a, b) + z.rad()
     if start_dec > 85.0:  # Coordinates are close to the pole
-        final_dec = sqrt(a * a + b * b)
+        final_dec = acos(sqrt(a * a + b * b))
     else:
         final_dec = asin(c)
     # Convert results to Angles. Please note results are in radians


### PR DESCRIPTION
Per Meeus, *Astronomical Algorithms* 2nd ed. (ch. 21, p. 135), the near-pole declination comes from cos(d) = √(A² + B²), so it must be recovered with acos rather than returned as-is.

Excerpt from the book:
<img width="788" height="127" alt="image" src="https://github.com/user-attachments/assets/7f414a5c-dff2-466b-bf34-4aba12c2d74a" />

Comparison: https://github.com/soniakeys/meeus/blob/bfbd9ac2c7f709c94f1dee190c633d24a723f628/v3/precess/precess.go#L164