### PR TITLE
Fix: precession_newcomb crashes on every call

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -794,7 +794,7 @@ def precession_newcomb(
     if not (isinstance(p_motion_ra, Angle)
             and isinstance(p_motion_dec, Angle)):
         raise TypeError("Invalid input types")
-    tt = (start_epoch - 2415020.3135) / 36524.2199
+    tt = (start_epoch - Epoch(2415020.3135)) / 36524.2199
     t = (final_epoch - start_epoch) / 36524.2199
     # Correct starting coordinates by proper motion
     start_ra += p_motion_ra * t * 100.0


### PR DESCRIPTION
Per Meeus, *Astronomical Algorithms* 2nd ed. (ch. 21, p. 140), the Newcomb (FK4) precession measures time in Julian centuries from B1900.0, i.e. from JDE 2415020.3135, with T = ((JD)₀ − 2415020.3135) 
/ 36524.2199. The book subtracts two Julian-day numbers, so T is a number. pymeeus subtracts the bare float from an Epoch:

```python
tt = (start_epoch - 2415020.3135) / 36524.2199
```

Epoch subtraction is operand-dependent: Epoch - Epoch returns a float, but Epoch - float returns an Epoch. So `start_epoch - 2415020.3135` is an Epoch, and the following `/ 36524.2199` does `Epoch / float`, which is unsupported:
```python
>>> from pymeeus.Coordinates import precession_newcomb
>>> from pymeeus.Epoch import Epoch
>>> from pymeeus.Angle import Angle
>>> precession_newcomb(Epoch(2415020.3135), Epoch(2451545.0), Angle(10.0), Angle(40.0))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
    import platform
  File "/Users/bueny/Documents/private/pymeeus/pymeeus/Coordinates.py", line 797, in precession_newcomb
    tt = (start_epoch - 2415020.3135) / 36524.2199
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for /: 'Epoch' and 'float'
```

This fires on the first line for every input, before any astronomy runs, so the function has no working code path.

Excerpt from the book (ch. 21, p. 140):

$$T = \frac{(JD)_0 - 2415020.3135}{36524.2199} \qquad t = \frac{(JD) - (JD)_0}{36524.2199}$$