### PR TITLE
Fix: equation_of_time is off by 24h near the spring equinox and loses the sign under a minute

### DIFF
--- a/pymeeus/Sun.py
+++ b/pymeeus/Sun.py
@@ -573,7 +573,9 @@ class Sun(object):
         :type epoch: :py:class:`Epoch`
 
         :returns: Difference between apparent and mean time, as a tuple, in
-            minutes (int) and seconds (float) of time
+            minutes (int) and seconds (float) of time. Both share the sign of
+            the result, so a negative value under a minute returns e.g.
+            (0, -16.4); reconstruct the signed total as m + s/60.
         :rtype: tuple
         :raises: TypeError if input values are of wrong type.
 
@@ -607,16 +609,15 @@ class Sun(object):
         alpha = alpha.to_positive()
         # Now we need the nutation in longitude
         deltapsi = nutation_longitude(epoch)
-        e = l0() - 0.0057183 - alpha + deltapsi * cos(epsilon.rad())
-        # The following line is a fix devised by janbredenbeek to a problem
-        # that arises in cases where alpha was just past the spring equinox
-        # but l0 was still < 360. In those cases e was incorrectly calculated
-        # The solution is to keep e as a float and reduce to range -180..+180
+        # janbredenbeek fix: when alpha is just past the spring equinox while
+        # l0 is still < 360, e lands in (180,360)
+        e = l0() - 0.0057183 - alpha() + deltapsi() * cos(epsilon.rad())
         e = e - 360.0 * round(e / 360.0)
         e *= 4.0
-        # Extract seconds
-        s = (abs(e()) % 1) * 60.0
-        m = int(e())
+        # Split into minutes and seconds, both carrying the sign of e, so the
+        # sign survives even when |e| < 1 and m == 0 (e.g. (0, -16.4))
+        m = int(e)
+        s = (e - m) * 60.0
         return m, s
 
     @staticmethod

--- a/tests/test_sun.py
+++ b/tests/test_sun.py
@@ -183,6 +183,44 @@ def test_sun_equation_of_time():
         "ERROR: 2nd equation_of_time() test, 's' doesn't match"
 
 
+def test_sun_equation_of_time_spring_equinox():
+    """Tests equation_of_time() on a spring-equinox crossing"""
+
+    epoch = Epoch(2024, 3, 20.5)
+    m, s = Sun.equation_of_time(epoch)
+    minutes = m + s / 60.0
+
+    assert m == -7, \
+        "ERROR: 1st spring-equinox equation_of_time() test, 'm' doesn't match"
+
+    assert abs(minutes - (-7.306)) < 0.01, \
+        "ERROR: 2nd spring-equinox equation_of_time() test, E was not reduced"
+
+def test_sun_equation_of_time_sign_near_zero():
+    """Tests equation_of_time() keeps the sign for sub-minute E across |E|~0
+
+    Around the mid-April crossing E is under a minute in magnitude and changes
+    sign: about -0.27 min on 2024-04-14 and +0.21 min on 2024-04-16."""
+
+    bm, bs = Sun.equation_of_time(Epoch(2024, 4, 14.0))   # (minutes, signed sec)
+    am, asec = Sun.equation_of_time(Epoch(2024, 4, 16.0))
+    before = bm + bs / 60.0
+    after = am + asec / 60.0
+
+    assert bm == 0 and bs < 0.0, \
+        "ERROR: 1st near-zero equation_of_time() test, wrong sign (2024-04-14)"
+    assert abs(before - (-0.2728)) < 0.01, \
+        "ERROR: 2nd near-zero equation_of_time() test, value (2024-04-14) doesn't match"
+
+    assert am == 0 and asec > 0.0, \
+        "ERROR: 3rd near-zero equation_of_time() test, wrong sign (2024-04-16)"
+    assert abs(after - 0.2075) < 0.01, \
+        "ERROR: 4th near-zero equation_of_time() test, value (2024-04-16) doesn't match"
+
+    assert before < 0.0 < after, \
+        "ERROR: 5th near-zero equation_of_time() test, sides not distinguishable"
+
+
 def test_sun_ephemeris_physical_observations():
     """Tests the ephemeris_physical_observations() method of Sun class"""
 


### PR DESCRIPTION
Per Meeus, *Astronomical Algorithms* 2nd ed. (ch. 28, p. 184), the equation of time is a single signed quantity that "is always smaller than 20 minutes in absolute value," and "if |E| appears to be too large, add 24 hours to or subtract it from your result." `Sun.equation_of_time` has two independent bugs that break this.  

The single 1992-10-13 doctest (where `E = +13.71 min`) triggers neither.

Excerpt from the book (ch. 28, p. 184):

<img width="1023" height="83" alt="image" src="https://github.com/user-attachments/assets/e3207a42-e8b5-43a2-9937-462188879ca0" />

## First issue: the [-180 deg, 180 deg] reduction runs on an `Angle`, not a float

The reduction line `e = e - 360.0 * round(e / 360.0)` only works on a plain float. But `e` here is an `Angle`, because `l0() - 0.0057183 - alpha` is `float - Angle`, which returns an `Angle` (the same operand-dependent overloading as `Epoch` in #43). Every `Angle` wraps back into [0, 360) on each step, so the reduction undoes itself:

```python
e = e - 360.0 * round(e / 360.0)
# 360.0 * round(e/360) -> 360.0 * Angle(1.0) -> Angle(360.0) -> Angle(0.0)   # 360 wraps to 0
# e - Angle(0.0) == e                                                        # the -360 never happens
e *= 4.0
# Angle(1432.68) -> Angle(352.68)                                            # wraps mod 360 again
```

Near a spring-equinox crossing (`alpha` just past 0 while `L0` is still < 360, so the raw `E` lands in (180, 360)):

```python
>>> from pymeeus.Epoch import Epoch
>>> from pymeeus.Sun import Sun
>>> Sun.equation_of_time(Epoch(2024, 3, 20.5))
(352, 41.65852230350083)        # ~352.7 min; should be ~-7.3 min
```

The fix is to take the float value of every `Angle` operand so the reduction is real arithmetic, which is exactly Meeus' "subtract 24 hours" instruction.

## Second issue: the (minutes, seconds) split drops the sign for |E| < 1 minute

Meeus carries `E` as a single signed value (Example 28.a: `E = +13.70940 minutes`).  
The return splits it as `s = (abs(e()) % 1) * 60; m = int(e())`, so the sign lives only in `m`. For `|E| < 1` minute, `int(E)` truncates to a signless `0` and the seconds stay positive, so a negative value is indistinguishable from the positive one:

```python
>>> from pymeeus.Sun import Sun
>>> from pymeeus.Epoch import Epoch
>>> Sun.equation_of_time(Epoch(2024, 4, 14.0))   # true E ~ -0.27 min
(0, 16.36543219371124)          # reads as +0.27 min; the minus sign is gone
```

The fix keeps the documented `(minutes, seconds)` tuple but signs the seconds, so the sign survives at `m == 0` and `m + s/60` reconstructs every value.

After both fixes:

```python
>>> from pymeeus.Sun import Sun
>>> from pymeeus.Epoch import Epoch
>>> Sun.equation_of_time(Epoch(2024, 3, 20.5))
(-7, -18.34147769649917)       # -7.31 min
>>> Sun.equation_of_time(Epoch(2024, 4, 14.0))
(0, -16.36543219371124)         # -0.27 min, sign preserved
```

Another reference: AA+ `AAEquationOfTime.cpp` reduces `E` with `if (E > 180) E = -(360 - E);` and returns a single signed `double`: https://github.com/hodinkee/aaplus/blob/29c6a5bfbff23edcb6a8f1018e83280d1eaf2ccc/src/AAEquationOfTime.cpp#L62
