### PR TITLE
Fix: times_rise_transit_set transit time is off by whole days at some longitudes

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -1571,7 +1571,8 @@ def times_rise_transit_set(
         set_delta = interpol(n, delta1, delta2, delta3)
         # Compute the hour angles
         theta = theta0 + 360.985647 * m0
-        transit_ha = theta - longitude - transit_alpha
+        transit_ha = (theta - longitude - transit_alpha)()
+        transit_ha -= 360.0 * round(transit_ha / 360.0)
         delta_transit = transit_ha / (-360.0)
         theta = theta0 + 360.985647 * m1
         rise_ha = theta - longitude - rise_alpha
@@ -1586,7 +1587,7 @@ def times_rise_transit_set(
         delta_set = (set_ele - h0) / (
             360.0 * cos(set_delta.rad()) * cos(lat) * sin(set_ha.rad())
         )
-        m0 += delta_transit()
+        m0 += delta_transit
         m1 += delta_rise()
         m2 += delta_set()
     return (m1 * 24.0, m0 * 24.0, m2 * 24.0)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -363,6 +363,33 @@ def test_coordinates_times_rise_transit_set():
         "ERROR: 3rd times_rise_transit_set() test, 'setting' doesn't match"
 
 
+def test_coordinates_times_rise_transit_set_meridian_wrap():
+    """Tests times_rise_transit_set() for the transit hour-angle wrap"""
+
+    longitude = Angle(100.0)
+    latitude = Angle(20.0)
+    alpha1 = Angle(355.78345574714496)
+    delta1 = Angle(-1.8258186035760802)
+    alpha2 = Angle(356.69822727457387)
+    delta2 = Angle(-1.4303730291596641)
+    alpha3 = Angle(357.61220064819383)
+    delta3 = Angle(-1.0347700757255995)
+    h0 = Angle(-0.8333)
+    delta_t = 69.12317527622284
+    theta0 = Angle(174.58612143862533)
+    rising, transit, setting = times_rise_transit_set(longitude, latitude,
+                                                      alpha1, delta1,
+                                                      alpha2, delta2,
+                                                      alpha3, delta3, h0,
+                                                      delta_t, theta0)
+
+    assert abs(round(transit, 3) - 18.804) < TOL, \
+        "ERROR: 1st times_rise_transit_set_meridian_wrap test, transit wrapped by whole days"
+
+    assert rising < transit < setting + 24.0, \
+        "ERROR: 2nd times_rise_transit_set_meridian_wrap test, transit fell outside [rising, setting]"
+
+
 def test_coordinates_refraction_apparent2true():
     """Tests the refraction_apparent2true() method of Coordinates module"""
 


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms*, 2nd ed. (ch. 15, p. 103), the transit-time correction `Δm = -H / 360` requires the local hour angle `H` reduced to the interval -180° to +180°. The transit value can come out a whole number of days wrong, landing outside the body's own rising/setting window.

Excerpt from the book:
<img width="786" height="215" alt="image" src="https://github.com/user-attachments/assets/e9289fb0-4e92-42e9-b1f6-58a423a38534" />


**Fix:** Convert the hour angle to a float and reduce it to [-180, 180] before the linear correction.

## Minimal reproduction

Sun, 2026-03-17, observer at latitude 20° N, longitude 100° W (Meeus longitude positive west):

```python
from pymeeus.Coordinates import times_rise_transit_set
from pymeeus.Angle import Angle

rise, transit, setting = times_rise_transit_set(
    Angle(100.0),  Angle(20.0),                       # longitude (W+), latitude
    Angle(355.78345574714496), Angle(-1.8258186035760802),  # alpha/delta, prev day
    Angle(356.69822727457387), Angle(-1.4303730291596641),  # alpha/delta, current day
    Angle(357.61220064819383), Angle(-1.0347700757255995),  # alpha/delta, next day
    Angle(-0.8333), 69.12317527622284, Angle(174.58612143862533))  # h0, delta_t, theta0

print(f"rise={rise:.3f} h   transit={transit:.3f} h   set={setting:.3f} h")
# before:  rise=12.775 h   transit=66.799 h   set=0.832 h   <- transit ~2 days after rise/set
# after :  rise=12.775 h   transit=18.804 h   set=0.832 h   <- transit between rise and set
```

Before the fix the transit (66.799 h ≈ 2.78 days) falls outside the rise --> set window; after, it is the meridian crossing between them (18.804 h).