### PR TITLE
Fix: times_rise_transit_set discards the transit for circumpolar bodies

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -1571,7 +1571,8 @@ def times_rise_transit_set(
         set_delta = interpol(n, delta1, delta2, delta3)
         # Compute the hour angles
         theta = theta0 + 360.985647 * m0
-        transit_ha = theta - longitude - transit_alpha
+        transit_ha = (theta - longitude - transit_alpha)()
+        transit_ha -= 360.0 * round(transit_ha / 360.0)
         delta_transit = transit_ha / (-360.0)
         theta = theta0 + 360.985647 * m1
         rise_ha = theta - longitude - rise_alpha
@@ -1586,7 +1587,7 @@ def times_rise_transit_set(
         delta_set = (set_ele - h0) / (
             360.0 * cos(set_delta.rad()) * cos(lat) * sin(set_ha.rad())
         )
-        m0 += delta_transit()
+        m0 += delta_transit
         m1 += delta_rise()
         m2 += delta_set()
     return (m1 * 24.0, m0 * 24.0, m2 * 24.0)

--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -1429,8 +1429,9 @@ def times_rise_transit_set(
     """This function computes the times (in Universal Time UT) of rising,
     transit and setting of a given celestial body.
 
-    .. note:: If the body is circumpolar there are no rising, transit nor
-        setting times. In such a case a tuple with None's is returned
+    .. note:: If the body is circumpolar there are no rising nor setting times
+        (None is returned for both), but the transit (upper culmination) is
+        still computed and returned, since it does not depend on the horizon.
 
     .. note:: Care must be taken when interpreting the results. For instance,
         if the setting time is **smaller** than the rising time, it means that
@@ -1544,36 +1545,45 @@ def times_rise_transit_set(
     lat = latitude.rad()
     d2 = delta2.rad()
     hh0 = (sin(h) - sin(lat) * sin(d2)) / (cos(lat) * cos(d2))
-    # Check if the body is circumpolar. In such case, there are no rising,
-    # transit nor setting times, and a tuple with None's is returned
-    if abs(hh0) > 1.0:
-        return (None, None, None)
-    hh0 = acos(hh0)
-    hh0 = Angle(hh0, radians=True)
-    hh0.to_positive()
+    # |hh0| > 1 means the body never crosses the horizon h0: it is circumpolar
+    # (or never rises), so there are no rising nor setting times. The transit,
+    # however, does not depend on h0 and still exists, so it is
+    # always computed and returned; only m1/m2 (rise/set) are skipped.
+    circumpolar = abs(hh0) > 1.0
     m0 = (alpha2 + longitude - theta0) / 360.0
     m0 = m0()  # m0 is an Angle. Convert to float
-    m1 = m0 - hh0() / 360.0
-    m2 = m0 + hh0() / 360.0
+    if circumpolar:
+        m1 = None
+        m2 = None
+    else:
+        hh0 = acos(hh0)
+        hh0 = Angle(hh0, radians=True)
+        hh0.to_positive()
+        m1 = m0 - hh0() / 360.0
+        m2 = m0 + hh0() / 360.0
+        m1 = check_value(m1)
+        m2 = check_value(m2)
     m0 = check_value(m0)
-    m1 = check_value(m1)
-    m2 = check_value(m2)
     # Carry out this procedure twice
     for _ in range(2):
-        # Interpolate alpha and delta values for each (m0, m1, m2)
+        # Transit: interpolate alpha at m0 and correct by the hour angle,
+        # reduced to [-180, 180] before the linear -H/360 correction.
         n = m0 + delta_t / 86400.0
         transit_alpha = interpol(n, alpha1, alpha2, alpha3)
+        theta = theta0 + 360.985647 * m0
+        transit_ha = (theta - longitude - transit_alpha)()
+        transit_ha -= 360.0 * round(transit_ha / 360.0)
+        delta_transit = transit_ha / (-360.0)
+        m0 += delta_transit
+        if circumpolar:
+            continue
+        # Rising and setting (only when the body crosses the horizon)
         n = m1 + delta_t / 86400.0
         rise_alpha = interpol(n, alpha1, alpha2, alpha3)
         rise_delta = interpol(n, delta1, delta2, delta3)
         n = m2 + delta_t / 86400.0
         set_alpha = interpol(n, alpha1, alpha2, alpha3)
         set_delta = interpol(n, delta1, delta2, delta3)
-        # Compute the hour angles
-        theta = theta0 + 360.985647 * m0
-        transit_ha = (theta - longitude - transit_alpha)()
-        transit_ha -= 360.0 * round(transit_ha / 360.0)
-        delta_transit = transit_ha / (-360.0)
         theta = theta0 + 360.985647 * m1
         rise_ha = theta - longitude - rise_alpha
         theta = theta0 + 360.985647 * m2
@@ -1587,10 +1597,11 @@ def times_rise_transit_set(
         delta_set = (set_ele - h0) / (
             360.0 * cos(set_delta.rad()) * cos(lat) * sin(set_ha.rad())
         )
-        m0 += delta_transit
         m1 += delta_rise()
         m2 += delta_set()
-    return (m1 * 24.0, m0 * 24.0, m2 * 24.0)
+    rising = None if circumpolar else m1 * 24.0
+    setting = None if circumpolar else m2 * 24.0
+    return (rising, m0 * 24.0, setting)
 
 
 def refraction_apparent2true(apparent_elevation, pressure=1010.0,

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -363,6 +363,33 @@ def test_coordinates_times_rise_transit_set():
         "ERROR: 3rd times_rise_transit_set() test, 'setting' doesn't match"
 
 
+def test_coordinates_times_rise_transit_set_meridian_wrap():
+    """Tests times_rise_transit_set() for the transit hour-angle wrap"""
+
+    longitude = Angle(100.0)
+    latitude = Angle(20.0)
+    alpha1 = Angle(355.78345574714496)
+    delta1 = Angle(-1.8258186035760802)
+    alpha2 = Angle(356.69822727457387)
+    delta2 = Angle(-1.4303730291596641)
+    alpha3 = Angle(357.61220064819383)
+    delta3 = Angle(-1.0347700757255995)
+    h0 = Angle(-0.8333)
+    delta_t = 69.12317527622284
+    theta0 = Angle(174.58612143862533)
+    rising, transit, setting = times_rise_transit_set(longitude, latitude,
+                                                      alpha1, delta1,
+                                                      alpha2, delta2,
+                                                      alpha3, delta3, h0,
+                                                      delta_t, theta0)
+
+    assert abs(round(transit, 3) - 18.804) < TOL, \
+        "ERROR: 1st times_rise_transit_set_meridian_wrap test, transit wrapped by whole days"
+
+    assert rising < transit < setting + 24.0, \
+        "ERROR: 2nd times_rise_transit_set_meridian_wrap test, transit fell outside [rising, setting]"
+
+
 def test_coordinates_refraction_apparent2true():
     """Tests the refraction_apparent2true() method of Coordinates module"""
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -390,6 +390,47 @@ def test_coordinates_times_rise_transit_set_meridian_wrap():
         "ERROR: 2nd times_rise_transit_set_meridian_wrap test, transit fell outside [rising, setting]"
 
 
+def test_coordinates_times_rise_transit_set_circumpolar_transit():
+    """Tests times_rise_transit_set() returns the transit for a circumpolar body"""
+
+    longitude = Angle(0.0)
+    latitude = Angle(70.0)
+    alpha = Angle(6, 0, 0.0, ra=True)   # RA = 90 deg
+    delta = Angle(80.0)
+    h0 = Angle(-0.5667)
+    delta_t = 0.0
+    theta0 = Angle(100.0)
+    rising, transit, setting = times_rise_transit_set(longitude, latitude,
+                                                      alpha, delta,
+                                                      alpha, delta,
+                                                      alpha, delta, h0,
+                                                      delta_t, theta0)
+
+    assert rising is None and setting is None, \
+        "ERROR: 1st circumpolar_transit test, rising/setting should be None"
+
+    assert transit is not None, \
+        "ERROR: 2nd circumpolar_transit test, transit must be returned for a circumpolar body"
+
+    assert abs(round(transit, 3) - 23.270) < TOL, \
+        "ERROR: 3rd circumpolar_transit test, transit time doesn't match"
+
+    alpha1 = Angle(353.5)
+    alpha2 = Angle(0.0)
+    alpha3 = Angle(6.5)
+    rising, transit, setting = times_rise_transit_set(longitude, latitude,
+                                                      alpha1, delta,
+                                                      alpha2, delta,
+                                                      alpha3, delta, h0,
+                                                      69.0, Angle(0.5))
+
+    assert rising is None and setting is None, \
+        "ERROR: 4th circumpolar_transit test, rising/setting should be None"
+
+    assert abs(round(transit, 3) - 24.340) < TOL, \
+        "ERROR: 5th circumpolar_transit test, transit should be the true day-relative culmination"
+
+
 def test_coordinates_refraction_apparent2true():
     """Tests the refraction_apparent2true() method of Coordinates module"""
 


### PR DESCRIPTION
The transit does not depend on the "standard altitude" `h0`. The condition `cos H0 > 1` only means the body never reaches `h0`, i.e. it has no rising or setting but it still culminates once per sidereal day, so the transit is well-defined for any body at `latitude < 90°`. `times_rise_transit_set` instead returns `(None, None, None)` for every circumpolar body, throwing the transit away (and it returns *before* `m0` is even computed).

**Fix:** Compute (and refine) `m0` unconditionally; return `None` only for the rising and setting times when the body is circumpolar.

## Minimal reproduction

```python
from pymeeus.Coordinates import times_rise_transit_set
from pymeeus.Angle import Angle

rise, transit, setting = times_rise_transit_set(
    Angle(0.0), Angle(70.0),            # longitude (W+), latitude
    Angle(90.0), Angle(80.0),           # alpha/delta, prev day
    Angle(90.0), Angle(80.0),           # alpha/delta, current day
    Angle(90.0), Angle(80.0),           # alpha/delta, next day
    Angle(-0.5667), 0.0, Angle(100.0))  # h0, delta_t, theta0

print(f"rise={rise}   transit={transit}   set={setting}")
# before:  rise=None   transit=None   set=None                <- transit discarded
# after :  rise=None   transit=23.26962371553653   set=None   <- culmination returned
```

Before the fix a circumpolar body gets no transit at all; after, the upper culmination is returned, while rising and setting stay `None`.


This MR also contains the fix from #45  