### PR TITLE
Fix: orbital_equinox2equinox applies the i0 = 0 shortcut below 1 degree

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -2732,8 +2732,8 @@ def orbital_equinox2equinox(epoch0, epoch, i0, arg0, lon0):
     etar = eta.rad()
     lon0r = lon0.rad()
     pir = pie.rad()
-    # If i0 is very small, the procedure is different
-    if i0 < 1.0:
+    # Only at i0 = 0 the node is indeterminate; use the limiting case there
+    if i0 < 1e-9:
         i1 = eta
         lon1 = pie + p + 180.0
     else:


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* 2nd ed. (ch. 24, p. 159), `orbital_equinox2equinox` reduces orbital elements from one equinox to another, computing the new inclination and node from the auxiliary angles eta, Pi and p.  
Meeus gives the `i1 = eta`, `Omega1 = Pi + p + 180 deg` shortcut only at i0 = 0 exactly, where the node is indeterminate.  
The code applies it to every inclination below 1 degree.

Excerpt from the book (p. 160):

<img width="728" height="205" alt="image" src="https://github.com/user-attachments/assets/0db3d419-013f-4299-9b7a-8f35aca03113" />

Before:
```python
>>> from pymeeus.Coordinates import orbital_equinox2equinox
>>> from pymeeus.Epoch import Epoch
>>> from pymeeus.Angle import Angle
>>> e0, e1 = Epoch(2358042.5305), Epoch(2433282.4235)
>>> i1, arg1, lon1 = orbital_equinox2equinox(e0, e1, Angle(0.5), Angle(151.4486), Angle(45.7481))
>>> round(i1(), 4), round(lon1(), 4)    # should be (0.5164, 46.2128)
(0.027, 354.9172)
```

After:
```python
>>> i1, arg1, lon1 = orbital_equinox2equinox(e0, e1, Angle(0.5), Angle(151.4486), Angle(45.7481))
>>> round(i1(), 4), round(lon1(), 4)
(0.5164, 46.2128)
```