### PR TITLE
Fix: is_phenomena never flags a phenomenon

### DIFF
--- a/pymeeus/JupiterMoons.py
+++ b/pymeeus/JupiterMoons.py
@@ -1002,7 +1002,7 @@ class JupiterMoons(object):
 
         for row in range(len(result_matrix)):
             for col in range(len(result_matrix[row]) - 1):
-                result_matrix[row][col] = (1 >= dist_matrix[row][col] >= 1)
+                result_matrix[row][col] = (1 >= dist_matrix[row][col] >= 0)
 
         return result_matrix
 


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* 2nd ed. (ch. 44), a Galilean moon is occulted or eclipsed when its perspective distance d to Jupiter's center is within the disk (`|d| <= 1`) on the far side. Per the helpers' own sign convention, the far side is `d > 0` (`check_occultation`/`check_eclipse` return a negative distance when the moon is nearer than Jupiter, positive when farther), so a phenomenon means `0 <= d <= 1`.  
`is_phenomena` filtered with `1 >= d >= 1`, true only at `d == 1` exactly, so it returns False for every satellite at every epoch.  

Before:
```python
>>> from pymeeus.JupiterMoons import JupiterMoons
>>> from pymeeus.Epoch import Epoch
>>> e = Epoch(2021, 2, 12.5966898148148)   # Io eclipse begins
>>> JupiterMoons.is_phenomena(e)[0]        # Io; should be [False, True, False]
[False, False, False]
```

After:
```python
>>> JupiterMoons.is_phenomena(e)[0]
[False, True, False]
```

Note: 
- Regressed in https://github.com/architest/pymeeus/commit/1f8b40483dc65fb31bb5a480f4c725fb816bfddd, which changed the original `1 >= d >= 0` to `>= 1`. (The commit aimed for "-1 to 1", but the near side `d < 0` is a transit, not an occultation/eclipse, so the original `>= 0` is correct.)
- There was a failing test because of this issue which now also passes.