### PR TITLE
Fix: check_phenomena(check_all=False) passes X for all of X, Y, Z

### DIFF
--- a/pymeeus/JupiterMoons.py
+++ b/pymeeus/JupiterMoons.py
@@ -942,12 +942,12 @@ class JupiterMoons(object):
             return result_matrix
         else:
             return JupiterMoons.check_occultation(Coords_Earth[i_sat - 1][0],
-                                                  Coords_Earth[i_sat - 1][0],
+                                                  Coords_Earth[i_sat - 1][1],
                                                   Coords_Earth[i_sat - 1][
-                                                      0]), \
+                                                      2]), \
                 JupiterMoons.check_eclipse(
-                Coords_Sun[i_sat - 1][0], Coords_Sun[i_sat - 1][0],
-                Coords_Sun[i_sat - 1][0])
+                Coords_Sun[i_sat - 1][0], Coords_Sun[i_sat - 1][1],
+                Coords_Sun[i_sat - 1][2])
 
     @staticmethod
     def is_phenomena(epoch):


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* 2nd ed. (ch. 44), a Galilean moon's perspective distance to Jupiter's center is `sqrt(X^2 + (1.071374*Y)^2)`, with Z setting the sign (near/far), so X, Y and Z each play a distinct role.  
The default `check_all=True` path unpacks the three coordinates correctly.  
The non-default `check_all=False` branch passed `[0]` (X) for all three arguments of both `check_occultation` and `check_eclipse`, so Y and Z (indices `[1]`, `[2]`) were never read.

Before:
```python
>>> from pymeeus.JupiterMoons import JupiterMoons
>>> from pymeeus.Epoch import Epoch
>>> e = Epoch(1992, 12, 16, utc=True)
>>> o, ecl = JupiterMoons.check_phenomena(e, check_all=False, i_sat=1)   # Io
>>> round(o, 4), round(ecl, 4)    # should be (-3.4578, -2.5533)
(-5.0564, -3.7274)
```

After:
```python
>>> o, ecl = JupiterMoons.check_phenomena(e, check_all=False, i_sat=1)
>>> round(o, 4), round(ecl, 4)
(-3.4578, -2.5533)
```

Comparison: the default `check_all=True` path (same method) returns the book values `-3.4578` / `-2.5533` for Io; the fixed `check_all=False` path now matches it.
