### PR TITLE
Fix: refraction scaling reduces an Angle, zeroing near-horizon refrac…

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -1635,7 +1635,7 @@ def refraction_apparent2true(apparent_elevation, pressure=1010.0,
         raise TypeError("Invalid input types")
     x = apparent_elevation + 7.31 / (apparent_elevation + 4.4)
     r = 1.0 / tan(x.rad()) + 0.0013515
-    r = Angle(r / 60.0)  # The 'r' value is in minutes of arc
+    r = r / 60.0  # The 'r' value is in minutes of arc
     if pressure != 1010.0 or temperature != 10.0:
         r = r * pressure / 1010.0 * 283.0 / (273.0 + temperature)
     return apparent_elevation - r
@@ -1686,7 +1686,7 @@ def refraction_true2apparent(true_elevation, pressure=1010.0,
         raise TypeError("Invalid input types")
     x = true_elevation + 10.3 / (true_elevation + 5.11)
     r = 1.02 / tan(x.rad()) + 0.0019279
-    r = Angle(r / 60.0)  # The 'r' value is in minutes of arc
+    r = r / 60.0  # The 'r' value is in minutes of arc
     if pressure != 1010.0 or temperature != 10.0:
         r = r * pressure / 1010.0 * 283.0 / (273.0 + temperature)
     return true_elevation + r


### PR DESCRIPTION
Per Meeus *Astronomical Algorithms* 2nd ed. (ch. 16), `refraction_apparent2true`/`refraction_true2apparent` scale the refraction by `R * (P / 1010) * (283 / (273 + T))`. R is an `Angle`, so the left-associative chain evaluates `r * pressure` first; since every `Angle` reduces mod 360 and near the horizon R exceeds `360 / pressure` (~0.48 deg at P = 747), `r * pressure` overflows 360 and is silently wrapped, collapsing the refraction to near zero at the horizon.

Excerpt from the book (p. 107):

<img width="545" height="131" alt="image" src="https://github.com/user-attachments/assets/5a3658b0-f1d4-4ca1-aa02-947d3997adfc" />

Before:
```python
>>> from pymeeus.Coordinates import refraction_true2apparent
>>> from pymeeus.Angle import Angle
>>> # true altitude 0.5 deg, P = 900 mb, T = 25 C (observer above sea level, near horizon)
>>> round(refraction_true2apparent(Angle(0, 30, 0.0), 900.0, 25.0)(), 6)   # should be 0.852681
0.514186
>>> # at the horizon the refraction is wrapped down to a small fraction
>>> round(refraction_true2apparent(Angle(0.0), 900.0, 25.0)(), 6)          # should be 0.408786
0.070292
```

After:
```python
>>> round(refraction_true2apparent(Angle(0, 30, 0.0), 900.0, 25.0)(), 6)
0.852681
>>> round(refraction_true2apparent(Angle(0.0), 900.0, 25.0)(), 6)
0.408786
```
