### PR TITLE
Fix: times_rise_transit_set returns phantom rise/set at a grazing crossing

### DIFF
--- a/pymeeus/Coordinates.py
+++ b/pymeeus/Coordinates.py
@@ -1567,6 +1567,12 @@ def times_rise_transit_set(
         m1 = check_value(m1)
         m2 = check_value(m2)
     m0 = check_value(m0)
+    # Geometric first estimates, kept as the fallback should a correction
+    # below turn out implausible (see the guard in the loop).
+    m1_init = m1
+    m2_init = m2
+    m1_frozen = False
+    m2_frozen = False
     # Carry out this procedure twice
     for _ in range(2):
         # Transit: interpolate alpha at m0 and correct by the hour angle,
@@ -1600,8 +1606,25 @@ def times_rise_transit_set(
         delta_set = (set_ele - h0) / (
             360.0 * cos(set_delta.rad()) * cos(lat) * sin(set_ha.rad())
         )
-        m1 += delta_rise()
-        m2 += delta_set()
+        # Step guard: a valid correction moves the estimate within its own
+        # crossing, so it can never exceed the half-day hour-angle span.
+        # Near a grazing crossing sin(ha) -> 0 invalidates the linearization
+        # and an unguarded step walks days away (and the next iteration then
+        # evaluates the interpolation far outside its window, compounding to
+        # corrections of weeks). Fall back to the geometric estimate for that
+        # root and stop correcting it; callers refine from there.
+        if not m1_frozen:
+            if abs(delta_rise()) > 0.5:
+                m1 = m1_init
+                m1_frozen = True
+            else:
+                m1 += delta_rise()
+        if not m2_frozen:
+            if abs(delta_set()) > 0.5:
+                m2 = m2_init
+                m2_frozen = True
+            else:
+                m2 += delta_set()
     rising = None if circumpolar else m1 * 24.0
     setting = None if circumpolar else m2 * 24.0
     return (rising, m0 * 24.0, setting)


### PR DESCRIPTION
The function that computes when a body rises, crosses the meridian, and sets starts with a good first guess for the setting time, then nudges it a couple of times to sharpen it. Each nudge divides by `sin(H)`, where `H` is how far the body is from due south when it touches the horizon.

For a normal setting `H` is a healthy angle and the nudge is small. But when a body only *just barely* dips to the horizon (a "grazing" set, common for the Moon seen from far-north latitudes), `H` is almost zero, so `sin(H)` is almost zero, and dividing by it produces an enormous nudge. One nudge throws the estimate not
minutes but *days* away. The next nudge is then computed from a point so far off that it makes things worse, and the function reports a moonset time like 389 hours (about 16 days) from the requested day, an event that does not exist.

A legitimate nudge can only ever move the guess within the same rise-to-set window, which is at most half a day wide. So any nudge bigger than half a day is not a real correction, it is the calculation breaking down.

Concrete example (Moon, year 13, 22 December, high northern latitude):

| latitude | setting time returned (buggy) | setting time (correct) |
|---|---|---|
| 61.0 deg | 37.3 hours   | 13.2 hours |
| 61.1 deg | 389.4 hours  | 13.1 hours |


Before:
```python
>>> from pymeeus.Angle import Angle
>>> from pymeeus.Coordinates import times_rise_transit_set
>>> # Moon apparent RA/Dec at 0h TD on 0013-12-21 / -22 / -23; a young crescent
>>> # whose diurnal arc barely clears the horizon at latitude 61.1 deg
>>> rising, transit, setting = times_rise_transit_set(
...     Angle(-89.8), Angle(61.1),
...     Angle(262.0147698256), Angle(-28.0285215200),
...     Angle(279.4044051918), Angle(-28.3676715704),
...     Angle(296.4258016266), Angle(-26.5431300711),
...     Angle(0.125), 10291.8794055557, Angle(3.6781774569))
>>> round(setting, 3)     # should be 13.095, the true moonset within the day
389.415
```

After:
```python
>>> rising, transit, setting = times_rise_transit_set(
...     Angle(-89.8), Angle(61.1),
...     Angle(262.0147698256), Angle(-28.0285215200),
...     Angle(279.4044051918), Angle(-28.3676715704),
...     Angle(296.4258016266), Angle(-26.5431300711),
...     Angle(0.125), 10291.8794055557, Angle(3.6781774569))
>>> round(setting, 3)
13.095
```

## The fix

Remember the original first guess. If a nudge would move the setting time by more than half a day, throw the nudge away, keep the first guess, and stop nudging that value. 

The rising time and the setting time are handled separately, and the
meridian-crossing time (which never had this problem) is left alone. For every ordinary rise and set the nudges are tiny, well under the half-day limit, so nothing about the normal results changes.